### PR TITLE
Fixed accessibility index bug

### DIFF
--- a/app/front_end/js/data_preparation.js
+++ b/app/front_end/js/data_preparation.js
@@ -255,6 +255,7 @@ function IsochronesPOISTimeUpdate (){
 	var reqPromises = [];
 	for (var key in thematic_data){
 		//Since obj id the same for each interval we get it from first elemen
+		if (key.includes("_json")) {break;}
 		var objId = thematic_data[key][0].objectid;
 		objIds.push(objId);
 		var  isoTimeReqUrl = ApiConstants.address_geoserver+'wfs?service=WFS&version=1.1.0&request=GetFeature&viewparams=objectid:'+objId.toString()+';day:'+day.toString()+';hour:'+time.toString()+'&typeName=cite:isochrones_time&outputFormat=application/json';


### PR DESCRIPTION
When accessibility index is calculated a new key is added on Thematic Data object like "Default_1_json", which contains calculation accessibility indexes. 
The error was on the Isochrone Pois Time update which considers all thematic data properties the same. 
A loop break is added to avoid this error. 